### PR TITLE
Add Telegram mini app and bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,18 @@
+import os
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+WEBAPP_URL = os.environ.get("WEBAPP_URL", "https://example.com/index.html")
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    keyboard = [[InlineKeyboardButton(text="Открыть мини-приложение", web_app=WebAppInfo(url=WEBAPP_URL))]]
+    reply_markup = InlineKeyboardMarkup(keyboard)
+    await update.message.reply_text("Запусти мини-приложение:", reply_markup=reply_markup)
+
+if __name__ == "__main__":
+    token = os.environ.get("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN is not set")
+    app = ApplicationBuilder().token(token).build()
+    app.add_handler(CommandHandler("start", start))
+    app.run_polling()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>BTC Price App</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <style>
+        body {font-family: Arial, sans-serif; text-align: center; margin-top: 50px;}
+        #username {font-size: 20px; margin-bottom: 20px;}
+        #price {font-size: 32px; font-weight: bold;}
+    </style>
+</head>
+<body>
+    <div id="username"></div>
+    <div id="price">Загрузка...</div>
+    <script>
+        const tg = window.Telegram.WebApp;
+        tg.expand();
+        const user = tg.initDataUnsafe && tg.initDataUnsafe.user;
+        const userEl = document.getElementById('username');
+        if (user) {
+            if (user.username) {
+                userEl.textContent = `${user.username} (ID: ${user.id})`;
+            } else {
+                userEl.textContent = `ID: ${user.id}`;
+            }
+        }
+
+        const priceEl = document.getElementById('price');
+        let lastDisplayed = null;
+        let latestPrice = null;
+
+        const ws = new WebSocket('wss://stream.binance.com:9443/ws/btcusdt@trade');
+        ws.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+            latestPrice = parseFloat(data.p);
+        };
+
+        setInterval(() => {
+            if (latestPrice !== null) {
+                const formatted = latestPrice.toFixed(2);
+                if (lastDisplayed !== null) {
+                    if (formatted > lastDisplayed) {
+                        priceEl.style.color = 'green';
+                    } else if (formatted < lastDisplayed) {
+                        priceEl.style.color = 'red';
+                    } else {
+                        priceEl.style.color = 'black';
+                    }
+                }
+                priceEl.textContent = formatted;
+                lastDisplayed = formatted;
+            }
+        }, 1000);
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pygame
-random
-math
+python-telegram-bot


### PR DESCRIPTION
## Summary
- Add index.html to display Telegram user info and live BTC price via Binance WebSocket
- Add bot.py with /start command that opens the mini app
- Update requirements with python-telegram-bot

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68c70167db1c8321a84b9cc3d7983bf3